### PR TITLE
Equalizes satchels and backpacks

### DIFF
--- a/code/datums/storage/subtypes/backpack.dm
+++ b/code/datums/storage/subtypes/backpack.dm
@@ -24,7 +24,7 @@
 	max_storage_space = 400 // can store a ton of shit!
 
 /datum/storage/backpack/satchel //Smaller, but no delay
-	max_storage_space = 20
+	max_storage_space = 30
 	access_delay = 0
 
 /datum/storage/backpack/tech/New(atom/parent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have raised the capacity of satchels to 30, so that they're equal to backpacks. This is because backpacks had their delay, their only downside, removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You are no longer penalized for taking a satchel instead of a backpack
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Satchels now hold 30, making them equivalent in capacity to backpacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
